### PR TITLE
Check only type and UserID when comparing FederatedIdentity

### DIFF
--- a/pkg/controller/keycloakuser/keycloakuser_reconciler.go
+++ b/pkg/controller/keycloakuser/keycloakuser_reconciler.go
@@ -266,8 +266,7 @@ func containsRoleID(list []string, id string) bool {
 func containsIdentity(list []v1alpha1.FederatedIdentity, identity v1alpha1.FederatedIdentity) bool {
 	for _, item := range list {
 		if item.UserID == identity.UserID &&
-			item.IdentityProvider == identity.IdentityProvider &&
-			item.UserName == identity.UserName {
+			item.IdentityProvider == identity.IdentityProvider {
 			return true
 		}
 	}


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/INTLY-5468

Checking type and UserID will sufficient, and it will allow us to avoid issues with upper case usernames.